### PR TITLE
Allow hosted zone name to be specified as a target for a domain

### DIFF
--- a/src/cmdlinetest/test_aws-certificate-management.t
+++ b/src/cmdlinetest/test_aws-certificate-management.t
@@ -3,30 +3,38 @@
 
 
   $ aws-certificate-management --help
-  usage: aws-certificate-management [-h] [-v] [-q] [--region REGION] [-c] domain
+  usage: aws-certificate-management [-h] [-v] [-q] [--region REGION]
+                                    [--hosted_zone HOSTED_ZONE] [-c]
+                                    domain
   
   Tool to create AWS certificates
   
   positional arguments:
-    domain           For which domain you need a certificate. Can also be a
-                     wildcard like "*.foo.bar"
+    domain                For which domain you need a certificate. Can also be a
+                          wildcard like "*.foo.bar"
   
   optional arguments:
-    -h, --help       show this help message and exit
+    -h, --help            show this help message and exit
     -v, --verbose
     -q, --quiet
-    --region REGION  For which region the certificate is created (default is eu-
-                     west-1)
-    -c, --cleanup    Clean up stacks and resources that are only needed to
-                     request the certificate
+    --region REGION       For which region the certificate is created (default
+                          is eu-west-1)
+    --hosted_zone HOSTED_ZONE
+                          For which hosted zone the domain is registered
+    -c, --cleanup         Clean up stacks and resources that are only needed to
+                          request the certificate
 
 Missing "domain" parameter
   $ aws-certificate-management --cleanup
-  usage: aws-certificate-management [-h] [-v] [-q] [--region REGION] [-c] domain
+  usage: aws-certificate-management [-h] [-v] [-q] [--region REGION]
+                                    [--hosted_zone HOSTED_ZONE] [-c]
+                                    domain
   aws-certificate-management: error: .* (re)
   [2]
 
   $ aws-certificate-management
-  usage: aws-certificate-management [-h] [-v] [-q] [--region REGION] [-c] domain
+  usage: aws-certificate-management [-h] [-v] [-q] [--region REGION]
+                                    [--hosted_zone HOSTED_ZONE] [-c]
+                                    domain
   aws-certificate-management: error: .* (re)
   [2]

--- a/src/integrationtest/python/dns_tests.py
+++ b/src/integrationtest/python/dns_tests.py
@@ -2,28 +2,27 @@ import unittest2
 
 from aws_certificate_management.configure_dns import create_ses_dns_records, delete_ses_dns_records_and_bucket
 import dns.resolver
-import logging
 
 
 class DNSTests(unittest2.TestCase):
 
-    def test_create_ses_dns_records_wildcard(self):
+    def test_create_ses_dns_records_wildcard_in_same_hosted_zone(self):
         try:
-            create_ses_dns_records("*.pro-test.wolke.is")
+            create_ses_dns_records("*.pro-test.wolke.is", "pro-test.wolke.is")
 
             answers = dns.resolver.query('pro-test.wolke.is', 'MX')
             self.assertEqual(str(answers[0]), "10 inbound-smtp.eu-west-1.amazonaws.com.")
         finally:
-            delete_ses_dns_records_and_bucket("*.pro-test.wolke.is")
+            delete_ses_dns_records_and_bucket("*.pro-test.wolke.is", "pro-test.wolke.is")
 
-    def test_create_ses_dns_records_for_www(self):
+    def test_create_ses_dns_records_for_www_in_same_hosted_zone(self):
         try:
-            create_ses_dns_records("www.pro-test.wolke.is")
+            create_ses_dns_records("www.pro-test.wolke.is", "pro-test.wolke.is")
 
             answers = dns.resolver.query('pro-test.wolke.is', 'MX')
             self.assertEqual(str(answers[0]), "10 inbound-smtp.eu-west-1.amazonaws.com.")
         finally:
-            delete_ses_dns_records_and_bucket("www.pro-test.wolke.is")
+            delete_ses_dns_records_and_bucket("www.pro-test.wolke.is", "pro-test.wolke.is")
 
 
 if __name__ == "__main__":

--- a/src/integrationtest/python/init_tests.py
+++ b/src/integrationtest/python/init_tests.py
@@ -22,28 +22,30 @@ class SetupCertificateTests(unittest2.TestCase):
 
     def test_setup_certificate_called_twice_wildcard(self):
         with self.assertLogs(logger='aws-certificate-management', level='INFO') as cm:
-            setup_certificate(WILDCARD_DOMAIN, 'eu-west-1')
-            setup_certificate(WILDCARD_DOMAIN, 'eu-west-1')
+            setup_certificate(WILDCARD_DOMAIN, WILDCARD_DOMAIN, 'eu-west-1')
+            setup_certificate(WILDCARD_DOMAIN, WILDCARD_DOMAIN, 'eu-west-1')
 
         logged_messages = "".join(cm.output)
         self.assertIn(ACM_ARN_PREFIX, logged_messages)
 
     def test_setup_certificate_called_twice_www(self):
         with self.assertLogs(logger='aws-certificate-management', level='INFO') as cm:
-            setup_certificate(WWW_DOMAIN, 'eu-west-1')
-            setup_certificate(WWW_DOMAIN, 'eu-west-1')
+            setup_certificate(WWW_DOMAIN, WWW_DOMAIN, 'eu-west-1')
+            setup_certificate(WWW_DOMAIN, WWW_DOMAIN, 'eu-west-1')
 
         logged_messages = "".join(cm.output)
         self.assertIn(ACM_ARN_PREFIX, logged_messages)
 
     def test_setup_certificate_different_regions(self):
         with self.assertLogs(level='INFO') as cm:
-            setup_certificate(WILDCARD_DOMAIN, 'eu-west-1')
-            setup_certificate(WILDCARD_DOMAIN, 'eu-central-1')
+            setup_certificate(WILDCARD_DOMAIN, WILDCARD_DOMAIN, 'eu-west-1')
+            setup_certificate(WILDCARD_DOMAIN, WILDCARD_DOMAIN, 'eu-central-1')
 
         logged_messages = "".join(cm.output)
         self.assertIn(ACM_ARN_PREFIX, logged_messages)
         self.assertIn(ACM_ARN_PREFIX2, logged_messages)
+        
+
 
 
 

--- a/src/integrationtest/python/ses_tests.py
+++ b/src/integrationtest/python/ses_tests.py
@@ -19,7 +19,7 @@ from aws_certificate_management.configure_dns import delete_items_in_bucket
 class SESTests(unittest2.TestCase):
     @classmethod
     def setup_bucket_policy(cls):
-        sts_client = boto3.client('sts')
+        sts_client = boto3.client('sts', region_name='eu-west-1')
         account_id = sts_client.get_caller_identity()['Account']
         policy_document = {
             "Version": "2008-10-17",
@@ -46,7 +46,7 @@ class SESTests(unittest2.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.s3_client = boto3.client('s3')
+        cls.s3_client = boto3.client('s3', region_name='eu-west-1')
         cls.s3_bucket = "aws-certificate-management-tests"
         cls.s3_bucket += str(random.randint(0, 2**64))
 

--- a/src/main/cfn/templates/recordset.json
+++ b/src/main/cfn/templates/recordset.json
@@ -5,6 +5,10 @@
       "Type": "String", 
       "Description": "The name of the domain. You must specify a fully qualified domain name that ends with a period as the last label indication. If you omit the final period, AWS CloudFormation adds it."
     }, 
+    "targetHostedZoneName": {
+      "Type": "String", 
+      "Description": "The name of the hosted zone that holds the domain."
+    }, 
     "dkimOne": {
       "Type": "String", 
       "Description": "sub domain value for '.dkim.amazonses.com.' CNAME record"
@@ -28,7 +32,7 @@
       "Type": "AWS::Route53::RecordSet", 
       "Properties": {
         "HostedZoneName": {
-          "Ref": "dnsBaseName"
+          "Ref": "targetHostedZoneName"
         }, 
         "TTL": "900", 
         "Type": "MX", 
@@ -44,7 +48,7 @@
       "Type": "AWS::Route53::RecordSet", 
       "Properties": {
         "HostedZoneName": {
-          "Ref": "dnsBaseName"
+          "Ref": "targetHostedZoneName"
         }, 
         "TTL": "900", 
         "Type": "CNAME", 
@@ -81,7 +85,7 @@
       "Type": "AWS::Route53::RecordSet", 
       "Properties": {
         "HostedZoneName": {
-          "Ref": "dnsBaseName"
+          "Ref": "targetHostedZoneName"
         }, 
         "TTL": "900", 
         "Type": "CNAME", 
@@ -118,7 +122,7 @@
       "Type": "AWS::Route53::RecordSet", 
       "Properties": {
         "HostedZoneName": {
-          "Ref": "dnsBaseName"
+          "Ref": "targetHostedZoneName"
         }, 
         "TTL": "900", 
         "Type": "TXT", 
@@ -153,7 +157,7 @@
       "Type": "AWS::Route53::RecordSet", 
       "Properties": {
         "HostedZoneName": {
-          "Ref": "dnsBaseName"
+          "Ref": "targetHostedZoneName"
         }, 
         "TTL": "900", 
         "Type": "CNAME", 
@@ -177,7 +181,7 @@
       "Type": "AWS::Route53::RecordSet", 
       "Properties": {
         "HostedZoneName": {
-          "Ref": "dnsBaseName"
+          "Ref": "targetHostedZoneName"
         }, 
         "TTL": "900", 
         "Type": "CNAME", 

--- a/src/main/python/aws_certificate_management/__init__.py
+++ b/src/main/python/aws_certificate_management/__init__.py
@@ -13,8 +13,8 @@ __all__ = ["setup_ses_rule_set", "create_ses_dns_records",
            "setup_certificate", "cleanup"]
 
 
-def setup_certificate(domain, region):
-    mail_bucket_name = create_ses_dns_records(domain)
+def setup_certificate(domain, hosted_zone, region):
+    mail_bucket_name = create_ses_dns_records(domain, hosted_zone)
     setup_ses_rule_set(domain, mail_bucket_name)
 
     client = boto3.client('acm', region_name=region)
@@ -24,6 +24,6 @@ def setup_certificate(domain, region):
         "Your certificate ARN is %r", certificate_arn)
 
 
-def cleanup(domain):
-    delete_ses_dns_records_and_bucket(domain)
+def cleanup(domain, hosted_zone):
+    delete_ses_dns_records_and_bucket(domain, hosted_zone)
     cleanup_ses_rule_set(domain)

--- a/src/main/python/aws_certificate_management/stack_templates.py
+++ b/src/main/python/aws_certificate_management/stack_templates.py
@@ -6,6 +6,10 @@ RECORDSET_STACK = br"""
       "Type": "String",
       "Description": "The name of the domain. You must specify a fully qualified domain name that ends with a period as the last label indication. If you omit the final period, AWS CloudFormation adds it."
     },
+    "targetHostedZoneName": {
+      "Type": "String",
+      "Description": "The name of the hosted zone that holds the domain."
+    },
     "dkimOne": {
       "Type": "String",
       "Description": "sub domain value for '.dkim.amazonses.com.' CNAME record"
@@ -29,7 +33,7 @@ RECORDSET_STACK = br"""
       "Type": "AWS::Route53::RecordSet",
       "Properties": {
         "HostedZoneName": {
-          "Ref": "dnsBaseName"
+          "Ref": "targetHostedZoneName"
         },
         "TTL": "900",
         "Type": "MX",
@@ -45,7 +49,7 @@ RECORDSET_STACK = br"""
       "Type": "AWS::Route53::RecordSet",
       "Properties": {
         "HostedZoneName": {
-          "Ref": "dnsBaseName"
+          "Ref": "targetHostedZoneName"
         },
         "TTL": "900",
         "Type": "CNAME",
@@ -82,7 +86,7 @@ RECORDSET_STACK = br"""
       "Type": "AWS::Route53::RecordSet",
       "Properties": {
         "HostedZoneName": {
-          "Ref": "dnsBaseName"
+          "Ref": "targetHostedZoneName"
         },
         "TTL": "900",
         "Type": "CNAME",
@@ -119,7 +123,7 @@ RECORDSET_STACK = br"""
       "Type": "AWS::Route53::RecordSet",
       "Properties": {
         "HostedZoneName": {
-          "Ref": "dnsBaseName"
+          "Ref": "targetHostedZoneName"
         },
         "TTL": "900",
         "Type": "TXT",
@@ -154,7 +158,7 @@ RECORDSET_STACK = br"""
       "Type": "AWS::Route53::RecordSet",
       "Properties": {
         "HostedZoneName": {
-          "Ref": "dnsBaseName"
+          "Ref": "targetHostedZoneName"
         },
         "TTL": "900",
         "Type": "CNAME",
@@ -178,7 +182,7 @@ RECORDSET_STACK = br"""
       "Type": "AWS::Route53::RecordSet",
       "Properties": {
         "HostedZoneName": {
-          "Ref": "dnsBaseName"
+          "Ref": "targetHostedZoneName"
         },
         "TTL": "900",
         "Type": "CNAME",

--- a/src/main/scripts/aws-certificate-management
+++ b/src/main/scripts/aws-certificate-management
@@ -22,6 +22,8 @@ def main():
     parser.add_argument('--region', dest='region', default='eu-west-1',
                         help='For which region the certificate is created '
                              '(default is eu-west-1)')
+    parser.add_argument('--hosted_zone', dest='hosted_zone',
+                        help='For which hosted zone the domain is registered')
     parser.add_argument('domain',
                         help=('For which domain you need a certificate. '
                               'Can also be a wildcard like "*.foo.bar"'))
@@ -32,10 +34,12 @@ def main():
     args = parser.parse_args()
 
     setup_logging(args.log_level)
+    if args.hosted_zone is None:
+        args.hosted_zone = args.domain
     if args.cleanup:
-        cleanup(args.domain)
+        cleanup(args.domain, args.hosted_zone)
     else:
-        setup_certificate(args.domain, args.region)
+        setup_certificate(args.domain, args.hosted_zone, args.region)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In our we wanted to create a jump host subdomain in a already existing hosted zone on route 53. Unfortunately, by only allowing to specify a domain, aws-certificate-management tries to create a new hosted zone for the subdomain. This commit adds additional, optional flag so that one can specify exact hosted zone in which the domain that needs a certificate is managed.
